### PR TITLE
build: use `fork-ts-checker-webpack-plugin` for type checking

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 module.exports = (baseConfig, env, config) => {
   config.module.rules.push({
@@ -8,7 +9,8 @@ module.exports = (baseConfig, env, config) => {
       {
         loader: require.resolve('awesome-typescript-loader'),
         options: {
-          configFileName: '.storybook/tsconfig.json'
+          configFileName: '.storybook/tsconfig.json',
+          transpileOnly: true
         }
       },
       {
@@ -40,6 +42,13 @@ module.exports = (baseConfig, env, config) => {
     '@docs': path.resolve(__dirname, '../', 'docs')
   });
   config.resolve.mainFields = ['kata-kit:src', 'main'];
+
+  config.plugins.push(
+    new ForkTsCheckerWebpackPlugin({
+      tsconfig: '.storybook/tsconfig.json',
+      tslint: 'tslint.json'
+    })
+  );
 
   // Workaround for webpack v4.
   if (config.resolve.plugins) {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "dependency-graph": "^0.7.2",
     "execa": "^1.0.0",
     "file-loader": "^2.0.0",
+    "fork-ts-checker-webpack-plugin": "^0.4.15",
     "get-stream": "^4.0.0",
     "glob": "^7.1.3",
     "husky": "^1.0.0-rc.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3726,7 +3726,7 @@ chickencurry@1.1.1:
   resolved "https://registry.yarnpkg.com/chickencurry/-/chickencurry-1.1.1.tgz#02655f2b26b3bc2ee1ae1e5316886de38eb79738"
   integrity sha1-AmVfKyazvC7hrh5TFoht4463lzg=
 
-chokidar@^2.0.2:
+chokidar@^2.0.2, chokidar@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.4.tgz#356ff4e2b0e8e43e322d18a372460bbcf3accd26"
   integrity sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==
@@ -5724,6 +5724,20 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
+fork-ts-checker-webpack-plugin@^0.4.15:
+  version "0.4.15"
+  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-0.4.15.tgz#7cd9f94f3dd58cd1fe8f953f876e72090eda3f6d"
+  integrity sha512-qNYuygh2GxXehBvQZ5rI5YlQFn+7ZV6kmkyD9Sgs33dWl73NZdUOB5aCp8v0EXJn176AhPrZP8YCMT3h01fs+g==
+  dependencies:
+    babel-code-frame "^6.22.0"
+    chalk "^2.4.1"
+    chokidar "^2.0.4"
+    lodash "^4.17.11"
+    micromatch "^3.1.10"
+    minimatch "^3.0.4"
+    resolve "^1.5.0"
+    tapable "^1.0.0"
 
 form-data@~2.3.2:
   version "2.3.2"
@@ -10692,7 +10706,7 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.1.6, resolve@^1.3.2, resolve@^1.8.1:
+resolve@^1.1.6, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   integrity sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==


### PR DESCRIPTION
This speeds up the build time, since `awesome-typescript-loader` normally does type checking on the same process

Doesn't seem to affect the start up time too much, but definitely affects the hot reload time.

Before: https://i.imgur.com/mFcJPk9.png (62s)
After: https://i.imgur.com/NiLQ8VI.png (6s)