### PR TITLE
 feat(button): added new HollowButton + IconicButton styles

### DIFF
--- a/__stories__/2-components/button/Button.story.tsx
+++ b/__stories__/2-components/button/Button.story.tsx
@@ -10,6 +10,7 @@ import Button from '@kata-kit/button/src/components/Button';
 import FloatingButton from '@kata-kit/button/src/components/FloatingButton';
 import SupportButton from '@kata-kit/button/src/components/SupportButton';
 import ToggleButton from '@kata-kit/button/src/components/ToggleButton';
+import HollowButton from '@kata-kit/button/src/components/HollowButton';
 
 const StoryWrapper: StoryDecorator = storyFn => <Wrapper>{storyFn()}</Wrapper>;
 
@@ -161,6 +162,30 @@ story.add(
         </div>
       )}
     </WithState>
+  ),
+  { info: { disable: true } }
+);
+
+story.add(
+  'HollowButton',
+  () => (
+    <div>
+      <div style={{ marginBottom: '8px' }}>
+        <HollowButton>Push Me</HollowButton>
+      </div>
+      <div style={{ marginBottom: '8px' }}>
+        <HollowButton disabled>I'm Disabled</HollowButton>
+      </div>
+      <div style={{ marginBottom: '8px' }}>
+        <HollowButton loading>Loading...</HollowButton>
+      </div>
+      <div style={{ marginBottom: '8px' }}>
+        <HollowButton>
+          <i className="icon-arrow-left mr-1" />
+          Back
+        </HollowButton>
+      </div>
+    </div>
   ),
   { info: { disable: true } }
 );

--- a/__stories__/2-components/button/Button.story.tsx
+++ b/__stories__/2-components/button/Button.story.tsx
@@ -11,6 +11,7 @@ import FloatingButton from '@kata-kit/button/src/components/FloatingButton';
 import SupportButton from '@kata-kit/button/src/components/SupportButton';
 import ToggleButton from '@kata-kit/button/src/components/ToggleButton';
 import HollowButton from '@kata-kit/button/src/components/HollowButton';
+import IconicButton from '@kata-kit/button/src/components/IconicButton';
 
 const StoryWrapper: StoryDecorator = storyFn => <Wrapper>{storyFn()}</Wrapper>;
 
@@ -113,6 +114,87 @@ story.add(
 );
 
 story.add(
+  'HollowButton',
+  () => (
+    <div>
+      <div style={{ marginBottom: '8px' }}>
+        <HollowButton>Push Me</HollowButton>
+      </div>
+      <div style={{ marginBottom: '8px' }}>
+        <HollowButton disabled>I'm Disabled</HollowButton>
+      </div>
+      <div style={{ marginBottom: '8px' }}>
+        <HollowButton loading>Loading...</HollowButton>
+      </div>
+      <div style={{ marginBottom: '8px' }}>
+        <HollowButton>
+          <i className="icon-arrow-left mr-1" />
+          Back
+        </HollowButton>
+      </div>
+    </div>
+  ),
+  { info: { disable: true } }
+);
+
+story.add(
+  'IconicButton',
+  () => (
+    <div>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          marginBottom: '8px'
+        }}
+      >
+        <IconicButton style={{ marginRight: '8px' }}>
+          <i className="icon icon-arrow-left mr-1" />
+          Back
+        </IconicButton>
+        <IconicButton disabled>
+          <i className="icon icon-arrow-left mr-1" />
+          Back
+        </IconicButton>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          marginBottom: '8px'
+        }}
+      >
+        <IconicButton variant="primary" style={{ marginRight: '8px' }}>
+          <i className="icon icon-view mr-1" />
+          View
+        </IconicButton>
+        <IconicButton variant="primary" disabled>
+          <i className="icon icon-view mr-1" />
+          View
+        </IconicButton>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          marginBottom: '8px'
+        }}
+      >
+        <IconicButton variant="danger" style={{ marginRight: '8px' }}>
+          <i className="icon icon-trash mr-1" />
+          Delete
+        </IconicButton>
+        <IconicButton variant="danger" disabled>
+          <i className="icon icon-trash mr-1" />
+          Delete
+        </IconicButton>
+      </div>
+    </div>
+  ),
+  { info: { disable: true } }
+);
+
+story.add(
   'Button Styles',
   () => (
     <div>
@@ -162,30 +244,6 @@ story.add(
         </div>
       )}
     </WithState>
-  ),
-  { info: { disable: true } }
-);
-
-story.add(
-  'HollowButton',
-  () => (
-    <div>
-      <div style={{ marginBottom: '8px' }}>
-        <HollowButton>Push Me</HollowButton>
-      </div>
-      <div style={{ marginBottom: '8px' }}>
-        <HollowButton disabled>I'm Disabled</HollowButton>
-      </div>
-      <div style={{ marginBottom: '8px' }}>
-        <HollowButton loading>Loading...</HollowButton>
-      </div>
-      <div style={{ marginBottom: '8px' }}>
-        <HollowButton>
-          <i className="icon-arrow-left mr-1" />
-          Back
-        </HollowButton>
-      </div>
-    </div>
   ),
   { info: { disable: true } }
 );

--- a/packages/button/src/__tests__/HollowButton.test.tsx
+++ b/packages/button/src/__tests__/HollowButton.test.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { variables } from '@kata-kit/theme';
+import { render } from 'react-testing-library';
+import { HollowButton } from '..';
+
+import 'jest-dom/extend-expect';
+import 'jest-styled-components';
+
+describe('SupportButton', () => {
+  test('renders with correct colors', () => {
+    const { container } = render(<HollowButton>test button</HollowButton>);
+
+    expect(container.firstChild).toHaveStyleRule(
+      'color',
+      variables.colors.gray70
+    );
+  });
+
+  test('renders correctly as disabled', () => {
+    const { container } = render(
+      <HollowButton disabled>test button</HollowButton>
+    );
+
+    expect(container.firstChild).toHaveAttribute('disabled', '');
+  });
+
+  test('renders with loading icon', () => {
+    const { getByTestId } = render(
+      <HollowButton loading>test button</HollowButton>
+    );
+
+    const loader = getByTestId('circle-icon');
+    expect(loader).toBeInTheDocument();
+  });
+});

--- a/packages/button/src/__tests__/IconicButton.test.tsx
+++ b/packages/button/src/__tests__/IconicButton.test.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { variables } from '@kata-kit/theme';
+import { render } from 'react-testing-library';
+import { IconicButton } from '..';
+
+import 'jest-dom/extend-expect';
+import 'jest-styled-components';
+
+describe('SupportButton', () => {
+  test('renders with correct colors', () => {
+    const { container } = render(<IconicButton>test button</IconicButton>);
+
+    expect(container.firstChild).toHaveStyleRule(
+      'color',
+      variables.colors.gray70
+    );
+  });
+
+  test('renders with correct primary class', () => {
+    const { container } = render(
+      <IconicButton variant="primary">test button</IconicButton>
+    );
+
+    expect(container.firstChild).toHaveClass('primary');
+  });
+
+  test('renders with correct danger class', () => {
+    const { container } = render(
+      <IconicButton variant="danger">test button</IconicButton>
+    );
+
+    expect(container.firstChild).toHaveClass('danger');
+  });
+});

--- a/packages/button/src/components/Button.tsx
+++ b/packages/button/src/components/Button.tsx
@@ -8,6 +8,7 @@ import ThemedComponent, { variables } from '@kata-kit/theme';
 import themes from '../theme';
 
 import ButtonBase from '../styles';
+import { InvisibleText } from '../helpers';
 
 // TODO items:
 // - Cannot extend button below in other packages using `styled-components`, so
@@ -171,10 +172,6 @@ const isIconStyles = css`
       fill: ${variables.colors.kataBlue};
     }
   }
-`;
-
-const InvisibleText = styled('span')`
-  visibility: hidden;
 `;
 
 export const ButtonWrapper = styled('button')`

--- a/packages/button/src/components/HollowButton.tsx
+++ b/packages/button/src/components/HollowButton.tsx
@@ -1,0 +1,133 @@
+import React, { Fragment } from 'react';
+import classNames from 'classnames';
+import styled from 'styled-components';
+
+import { Circle } from '@kata-kit/loading';
+import { variables } from '@kata-kit/theme';
+
+import ButtonBase from '../styles';
+import { InvisibleText } from '../helpers';
+
+export interface HollowButtonProps {
+  disabled?: boolean;
+  size?: 'lg' | 'sm' | '';
+  className?: string;
+  onClick?: any;
+  block?: boolean;
+  active?: boolean;
+  outline?: boolean;
+  loading?: boolean;
+  children: any;
+}
+
+class HollowButton extends React.Component<HollowButtonProps> {
+  static defaultProps = {
+    block: false,
+    active: false,
+    disabled: false,
+    outline: false
+  };
+
+  onClick = e => {
+    if (this.props.disabled) {
+      e.preventDefault();
+      return;
+    }
+
+    if (this.props.onClick) {
+      this.props.onClick(e);
+    }
+  };
+
+  render() {
+    const {
+      className,
+      size,
+      block,
+      active,
+      disabled,
+      outline,
+      loading,
+      ...props
+    } = this.props;
+
+    const classes = classNames(
+      'btn',
+      'kata-btn__hollow',
+      size ? `btn-${size}` : false,
+      block ? `btn-block` : false,
+      {
+        active,
+        'position-relative': loading
+      },
+      className
+    );
+
+    return (
+      <HollowButtonWrapper
+        type="button"
+        {...props}
+        className={classes}
+        onClick={this.onClick}
+        disabled={disabled || loading}
+      >
+        {loading ? (
+          <Fragment>
+            <LoaderCircle size={30} />
+            <InvisibleText>{this.props.children}</InvisibleText>
+          </Fragment>
+        ) : (
+          this.props.children
+        )}
+      </HollowButtonWrapper>
+    );
+  }
+}
+
+const HollowButtonWrapper = styled('button')`
+  ${ButtonBase}
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 10px 16px;
+  border-radius: 6px;
+  font-weight: 700;
+  font-size: 13px;
+  line-height: 1.45;
+
+  color: ${variables.colors.gray70};
+  border: 1px solid ${variables.colors.gray30};
+  background: #fff;
+
+  &:disabled,
+  &.disabled {
+    color: ${variables.colors.gray50};
+  }
+
+  &:not(:disabled):not(.disabled) {
+    &:hover {
+      background-color: ${variables.colors.gray10};
+      color: ${variables.colors.gray70};
+    }
+
+    &:focus {
+      box-shadow: unset;
+
+      color: ${variables.colors.white};
+      background-color: ${variables.colors.gray70};
+    }
+  }
+
+  i::before {
+    height: unset;
+    line-height: unset;
+  }
+`;
+
+const LoaderCircle = styled(Circle)`
+  position: absolute;
+  left: 50%;
+  margin-left: -16px;
+`;
+
+export default HollowButton;

--- a/packages/button/src/components/IconicButton.tsx
+++ b/packages/button/src/components/IconicButton.tsx
@@ -2,14 +2,17 @@ import React, { Fragment } from 'react';
 import classNames from 'classnames';
 import styled from 'styled-components';
 
-import { Circle } from '@kata-kit/loading';
 import { variables } from '@kata-kit/theme';
 
 import ButtonBase from '../styles';
-import { InvisibleText } from '../helpers';
+import { darken } from 'polished';
 
-export interface HollowButtonProps {
+export interface IconicButtonProps {
+  /** Whether the button is disabled or not. */
   disabled?: boolean;
+  /** The color variant of the button. */
+  variant?: 'default' | 'primary' | 'danger';
+  /** The button size. */
   size?: 'md' | 'sm';
   /** Additional CSS classes to give to the button. */
   className?: string;
@@ -23,12 +26,14 @@ export interface HollowButtonProps {
   loading?: boolean;
 }
 
-class HollowButton extends React.Component<HollowButtonProps> {
+class IconicButton extends React.Component<IconicButtonProps> {
   static defaultProps = {
     block: false,
     active: false,
     disabled: false,
-    outline: false
+    outline: false,
+    size: 'md',
+    variant: 'default'
   };
 
   onClick = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -43,32 +48,39 @@ class HollowButton extends React.Component<HollowButtonProps> {
   };
 
   render() {
-    const { className, size, block, disabled, loading, ...props } = this.props;
+    const {
+      className,
+      size,
+      block,
+      disabled,
+      loading,
+      variant,
+      ...props
+    } = this.props;
 
-    const classes = classNames(className);
+    const classes = classNames(variant, className);
 
     return (
-      <HollowButtonWrapper
+      <IconicButtonWrapper
         type="button"
         {...props}
         className={classes}
         onClick={this.onClick}
-        disabled={disabled || loading}
+        disabled={disabled}
       >
         {loading ? (
           <Fragment>
-            <LoaderCircle size={30} />
-            <InvisibleText>{this.props.children}</InvisibleText>
+            <span className="invisible">{this.props.children}</span>
           </Fragment>
         ) : (
           this.props.children
         )}
-      </HollowButtonWrapper>
+      </IconicButtonWrapper>
     );
   }
 }
 
-const HollowButtonWrapper = styled('button')`
+const IconicButtonWrapper = styled('button')`
   ${ButtonBase}
   display: flex;
   justify-content: center;
@@ -82,10 +94,41 @@ const HollowButtonWrapper = styled('button')`
 
   color: ${variables.colors.gray70};
   border: 1px solid ${variables.colors.gray30};
-  background: #fff;
+  background: ${variables.colors.white};
+
+  &.primary {
+    color: ${variables.colors.kataBlue};
+
+    &:not(:disabled):not(.disabled) {
+      &:hover {
+        color: ${variables.colors.darkKataBlue};
+      }
+
+      &:focus {
+        color: ${variables.colors.white};
+        background-color: ${variables.colors.gray70};
+      }
+    }
+  }
+
+  &.danger {
+    color: ${variables.colors.red};
+
+    &:not(:disabled):not(.disabled) {
+      &:hover {
+        color: ${darken(0.15, variables.colors.red)};
+      }
+
+      &:focus {
+        color: ${variables.colors.white};
+        background-color: ${variables.colors.gray70};
+      }
+    }
+  }
 
   &:disabled,
   &.disabled {
+    background: ${variables.colors.gray10};
     color: ${variables.colors.gray50};
   }
 
@@ -109,10 +152,4 @@ const HollowButtonWrapper = styled('button')`
   }
 `;
 
-const LoaderCircle = styled(Circle)`
-  position: absolute;
-  left: 50%;
-  margin-left: -16px;
-`;
-
-export default HollowButton;
+export default IconicButton;

--- a/packages/button/src/helpers.ts
+++ b/packages/button/src/helpers.ts
@@ -1,0 +1,5 @@
+import styled from 'styled-components';
+
+export const InvisibleText = styled('span')`
+  visibility: hidden;
+`;

--- a/packages/button/src/index.ts
+++ b/packages/button/src/index.ts
@@ -9,6 +9,7 @@ import FloatingButton from './components/FloatingButton';
 import SupportButton from './components/SupportButton';
 import ToggleButton from './components/ToggleButton';
 import HollowButton, { HollowButtonProps } from './components/HollowButton';
+import IconicButton, { IconicButtonProps } from './components/IconicButton';
 
 import ButtonBase from './styles';
 
@@ -24,5 +25,7 @@ export {
   ToggleButton,
   HollowButton,
   HollowButtonProps,
+  IconicButton,
+  IconicButtonProps,
   ButtonBase
 };

--- a/packages/button/src/index.ts
+++ b/packages/button/src/index.ts
@@ -8,6 +8,9 @@ import ButtonGroup from './components/ButtonGroup';
 import FloatingButton from './components/FloatingButton';
 import SupportButton from './components/SupportButton';
 import ToggleButton from './components/ToggleButton';
+import HollowButton, { HollowButtonProps } from './components/HollowButton';
+
+import ButtonBase from './styles';
 
 export {
   Button,
@@ -18,5 +21,8 @@ export {
   ButtonSizes,
   FloatingButton,
   SupportButton,
-  ToggleButton
+  ToggleButton,
+  HollowButton,
+  HollowButtonProps,
+  ButtonBase
 };


### PR DESCRIPTION
Added two new button types, `HollowButton` and `IconicButton`.

**HollowButton**

![image](https://user-images.githubusercontent.com/5663877/49913019-9e6d3a80-febe-11e8-9e86-0216fdd8594e.png)

**IconicButton**

![image](https://user-images.githubusercontent.com/5663877/49913028-a88f3900-febe-11e8-8739-bad80b564a85.png)
