### PR TITLE
fix(layout): optionally allow menus to be NavLink

### DIFF
--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -4,11 +4,13 @@
 
 ## Install
 
+`@kata-kit/layout` requires `react-router`. To install, use:
+
 ```sh
 # yarn
-yarn add @kata-kit/layout
+yarn add @kata-kit/layout react-router-dom
 # npm
-npm install @kata-kit/layout
+npm install @kata-kit/layout react-router-dom
 ```
 
 ## Usage

--- a/packages/layout/src/__tests__/Layout.tsx
+++ b/packages/layout/src/__tests__/Layout.tsx
@@ -7,6 +7,8 @@ import { AppRoot, Topbar, SidebarSub } from '..';
 import SidebarAndContent from '../components/SidebarAndContent';
 import Sidebar from '../components/Sidebar';
 import SidebarMain from '../components/SidebarMain';
+import SidebarMainMenu from '../components/SidebarMainMenu';
+import SidebarSubMenu from '../components/SidebarSubMenu';
 import Content from '../components/Content';
 
 describe('Layout', () => {
@@ -20,9 +22,56 @@ describe('Layout', () => {
         />
         <SidebarAndContent hasTop>
           <Sidebar hasTop>
-            <SidebarMain>Menu</SidebarMain>
+            <SidebarMain>
+              <SidebarMainMenu icon="bot">Menu</SidebarMainMenu>
+              <SidebarMainMenu icon="bot">Menu</SidebarMainMenu>
+              <SidebarMainMenu icon="bot">Menu</SidebarMainMenu>
+            </SidebarMain>
             <SidebarSub titleElement={<h2>SidebarSubTitle</h2>}>
-              SidebarSubContent
+              <SidebarSubMenu icon="bot">SubMenu</SidebarSubMenu>
+              <SidebarSubMenu icon="bot">SubMenu</SidebarSubMenu>
+              <SidebarSubMenu icon="bot">SubMenu</SidebarSubMenu>
+            </SidebarSub>
+          </Sidebar>
+          <Content>Content</Content>
+        </SidebarAndContent>
+      </AppRoot>
+    );
+
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  test('renders correctly (with menu as NavLink)', () => {
+    const { container } = render(
+      <AppRoot>
+        <Topbar
+          leftContent={
+            <div style={{ width: '64px', textAlign: 'center' }}>Logo</div>
+          }
+        />
+        <SidebarAndContent hasTop>
+          <Sidebar hasTop>
+            <SidebarMain>
+              <SidebarMainMenu asNavLink icon="bot">
+                Menu
+              </SidebarMainMenu>
+              <SidebarMainMenu asNavLink icon="bot">
+                Menu
+              </SidebarMainMenu>
+              <SidebarMainMenu asNavLink icon="bot">
+                Menu
+              </SidebarMainMenu>
+            </SidebarMain>
+            <SidebarSub titleElement={<h2>SidebarSubTitle</h2>}>
+              <SidebarSubMenu asNavLink icon="bot">
+                SubMenu
+              </SidebarSubMenu>
+              <SidebarSubMenu asNavLink icon="bot">
+                SubMenu
+              </SidebarSubMenu>
+              <SidebarSubMenu asNavLink icon="bot">
+                SubMenu
+              </SidebarSubMenu>
             </SidebarSub>
           </Sidebar>
           <Content>Content</Content>

--- a/packages/layout/src/components/SidebarMainMenu.tsx
+++ b/packages/layout/src/components/SidebarMainMenu.tsx
@@ -1,11 +1,15 @@
 import * as React from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
+import { NavLinkProps, NavLink } from 'react-router-dom';
 import { variables } from '@kata-kit/theme';
 
 export interface SidebarMainMenuProps
   extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   className?: string;
   style?: React.CSSProperties;
+  asNavLink?: boolean;
+  to?: NavLinkProps['to'];
+  exact?: NavLinkProps['exact'];
   icon: string;
 }
 
@@ -13,16 +17,38 @@ const SidebarMainMenu: React.SFC<SidebarMainMenuProps> = ({
   className,
   style,
   icon,
+  asNavLink,
+  to,
+  exact,
   children,
   ...rest
-}) => (
-  <a className={className} style={style} {...rest}>
-    <Icon>
-      <i className={`icon-${icon}`} />
-    </Icon>
-    <Span>{children}</Span>
-  </a>
-);
+}) => {
+  if (asNavLink && to) {
+    return (
+      <RootNavLink
+        className={className}
+        style={style}
+        to={to}
+        exact={exact}
+        {...rest}
+      >
+        <Icon>
+          <i className={`icon-${icon}`} />
+        </Icon>
+        <Span>{children}</Span>
+      </RootNavLink>
+    );
+  }
+
+  return (
+    <RootAnchor className={className} style={style} {...rest}>
+      <Icon>
+        <i className={`icon-${icon}`} />
+      </Icon>
+      <Span>{children}</Span>
+    </RootAnchor>
+  );
+};
 
 const Icon = styled('div')`
   width: 40px;
@@ -39,7 +65,7 @@ const Span = styled('span')`
   color: #676b6d;
 `;
 
-export default styled(SidebarMainMenu)`
+const BaseStyles = css`
   margin: 0 0 16px;
   padding: 4px 0;
   font-size: 12px;
@@ -76,3 +102,13 @@ export default styled(SidebarMainMenu)`
     }
   }
 `;
+
+const RootAnchor = styled('a')`
+  ${BaseStyles}
+`;
+
+const RootNavLink = styled(NavLink)`
+  ${BaseStyles}
+`;
+
+export default SidebarMainMenu;

--- a/packages/layout/src/components/SidebarMainMenu.tsx
+++ b/packages/layout/src/components/SidebarMainMenu.tsx
@@ -30,6 +30,7 @@ const SidebarMainMenu: React.SFC<SidebarMainMenuProps> = ({
         style={style}
         to={to}
         exact={exact}
+        activeClassName="is-active"
         {...rest}
       >
         <Icon>

--- a/packages/layout/src/components/SidebarSub.tsx
+++ b/packages/layout/src/components/SidebarSub.tsx
@@ -4,7 +4,7 @@ import { variables } from '@kata-kit/theme';
 
 export interface SidebarSubProps
   extends React.AnchorHTMLAttributes<HTMLDivElement> {
-  titleElement?: React.ReactElement<any> | null;
+  titleElement?: React.ReactNode;
   hasTop?: boolean;
   collapsed?: boolean;
 }

--- a/packages/layout/src/components/SidebarSubMenu.tsx
+++ b/packages/layout/src/components/SidebarSubMenu.tsx
@@ -31,6 +31,7 @@ const SidebarSubMenu: React.SFC<SidebarSubMenuProps> = ({
         style={style}
         to={to}
         exact={exact}
+        activeClassName="is-active"
         {...rest}
       >
         {icon ? (

--- a/packages/layout/src/components/SidebarSubMenu.tsx
+++ b/packages/layout/src/components/SidebarSubMenu.tsx
@@ -1,32 +1,61 @@
 import * as React from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
+import { NavLinkProps, NavLink } from 'react-router-dom';
 
 import { variables } from '@kata-kit/theme';
 
 export interface SidebarSubMenuProps
   extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   className?: string;
-  to: string;
-  exact?: boolean;
-  icon?: string;
+  style?: React.CSSProperties;
+  asNavLink?: boolean;
+  to?: NavLinkProps['to'];
+  exact?: NavLinkProps['exact'];
+  icon: string;
 }
 
 const SidebarSubMenu: React.SFC<SidebarSubMenuProps> = ({
   className,
+  style,
   icon,
+  asNavLink,
+  to,
+  exact,
   children,
   ...rest
-}) => (
-  <a className={className} {...rest}>
-    {icon ? (
-      <Span>
-        <SubMenuIcon className={`icon-${icon}`} /> {children}
-      </Span>
-    ) : (
-      <Span>{children}</Span>
-    )}
-  </a>
-);
+}) => {
+  if (asNavLink && to) {
+    return (
+      <StyledNavLink
+        className={className}
+        style={style}
+        to={to}
+        exact={exact}
+        {...rest}
+      >
+        {icon ? (
+          <Span>
+            <SubMenuIcon className={`icon-${icon}`} /> {children}
+          </Span>
+        ) : (
+          <Span>{children}</Span>
+        )}
+      </StyledNavLink>
+    );
+  }
+
+  return (
+    <StyledAnchor className={className} style={style} {...rest}>
+      {icon ? (
+        <Span>
+          <SubMenuIcon className={`icon-${icon}`} /> {children}
+        </Span>
+      ) : (
+        <Span>{children}</Span>
+      )}
+    </StyledAnchor>
+  );
+};
 
 const SubMenuIcon = styled('i')`
   margin-right: 1.230769231rem /* $space-2 */;
@@ -40,7 +69,7 @@ const Span = styled('span')`
   color: ${variables.colors.gray70};
 `;
 
-export default styled(SidebarSubMenu)`
+const BaseStyles = css`
   display: block;
   min-height: 35px;
   padding: 6px 8px;
@@ -87,3 +116,13 @@ export default styled(SidebarSubMenu)`
     }
   }
 `;
+
+const StyledNavLink = styled(NavLink)`
+  ${BaseStyles}
+`;
+
+const StyledAnchor = styled('a')`
+  ${BaseStyles}
+`;
+
+export default SidebarSubMenu;


### PR DESCRIPTION
Turns out we still need `react-router-dom` for layout after all. This
allows the sidebar main/sub menus to be a NavLink with `asNavLink`.

This reverts the fixes made in #46.