### PR TITLE
fix(layout): fixed active state in SidebarSubMenu

### DIFF
--- a/packages/layout/src/components/SidebarSubMenu.tsx
+++ b/packages/layout/src/components/SidebarSubMenu.tsx
@@ -91,7 +91,8 @@ const BaseStyles = css`
   }
 
   &:active {
-    color: ${variables.colors.gray70};
+    background-color: ${variables.colors.gray70};
+    color: ${variables.colors.white};
 
     ${Span} {
       color: ${variables.colors.white};


### PR DESCRIPTION
When a link is clicked in `SidebarSubMenu`, it should've looked like this:

![image](https://user-images.githubusercontent.com/5663877/50067392-6d10a980-01f3-11e9-8662-bad0c0d65491.png)

However, we forgot to set the background color...