### PR TITLE
fix: fixed peerDependencies to be styled-components@^4.0.0

### DIFF
--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -29,6 +29,6 @@
   },
   "peerDependencies": {
     "react": "^16.3.0",
-    "styled-components": "^4.1.2"
+    "styled-components": "^4.0.0"
   }
 }

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "react": "^16.3.0",
-    "styled-components": "^4.1.2"
+    "styled-components": "^4.0.0"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.7"

--- a/packages/banner/package.json
+++ b/packages/banner/package.json
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "react": "^16.3.0",
-    "styled-components": "^4.1.2"
+    "styled-components": "^4.0.0"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.7"

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {
     "react": "^16.3.0",
-    "styled-components": "^4.1.2"
+    "styled-components": "^4.0.0"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.7"

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "react": "^16.3.0",
-    "styled-components": "^4.1.2"
+    "styled-components": "^4.0.0"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.7"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {
     "react": "^16.3.0",
-    "styled-components": "^4.1.2"
+    "styled-components": "^4.0.0"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.7"

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {
     "react": "^16.3.0",
-    "styled-components": "^4.1.2"
+    "styled-components": "^4.0.0"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.7"

--- a/packages/doc-utils/package.json
+++ b/packages/doc-utils/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "react": "^16.3.0",
-    "styled-components": "^4.1.2"
+    "styled-components": "^4.0.0"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.7"

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -33,7 +33,7 @@
   "peerDependencies": {
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
-    "styled-components": "^4.1.2"
+    "styled-components": "^4.0.0"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.7"

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
-    "styled-components": "^4.1.2"
+    "styled-components": "^4.0.0"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.7",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "react": "^16.3.0",
-    "styled-components": "^4.1.2"
+    "styled-components": "^4.0.0"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.7"

--- a/packages/kata-kit/package.json
+++ b/packages/kata-kit/package.json
@@ -53,7 +53,7 @@
   "peerDependencies": {
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
-    "styled-components": "^4.1.2"
+    "styled-components": "^4.0.0"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.7",

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -33,7 +33,7 @@
   "peerDependencies": {
     "react": "^16.3.0",
     "react-router-dom": "^4.3.1",
-    "styled-components": "^4.1.2"
+    "styled-components": "^4.0.0"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.7",

--- a/packages/loading/package.json
+++ b/packages/loading/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "react": "^16.3.0",
-    "styled-components": "^4.1.2"
+    "styled-components": "^4.0.0"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.7",

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
-    "styled-components": "^4.1.2"
+    "styled-components": "^4.0.0"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.7"

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {
     "react": "^16.3.0",
-    "styled-components": "^4.1.2"
+    "styled-components": "^4.0.0"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.7",

--- a/packages/react-select/package.json
+++ b/packages/react-select/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "react": "^16.3.0",
-    "styled-components": "^4.1.2"
+    "styled-components": "^4.0.0"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.7",

--- a/packages/reset/package.json
+++ b/packages/reset/package.json
@@ -29,6 +29,6 @@
   },
   "peerDependencies": {
     "react": "^16.3.0",
-    "styled-components": "^4.1.2"
+    "styled-components": "^4.0.0"
   }
 }

--- a/packages/split-button/package.json
+++ b/packages/split-button/package.json
@@ -32,7 +32,7 @@
   },
   "peerDependencies": {
     "react": "^16.3.0",
-    "styled-components": "^4.1.2"
+    "styled-components": "^4.0.0"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.7"

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -26,6 +26,6 @@
   "license": "Apache-2.0",
   "peerDependencies": {
     "react": "^16.3.0",
-    "styled-components": "^4.1.2"
+    "styled-components": "^4.0.0"
   }
 }

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
-    "styled-components": "^4.1.2"
+    "styled-components": "^4.0.0"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.7",


### PR DESCRIPTION
We should target an entire major version of styled-components instead of
pinning a certain major version upwards.