### PR TITLE
refactor: cleanup some uses of lodash

### DIFF
--- a/__mocks__/lodash-es/add.ts
+++ b/__mocks__/lodash-es/add.ts
@@ -1,0 +1,1 @@
+module.exports = a => a;

--- a/packages/common/src/components/Skeleton/Skeleton.tsx
+++ b/packages/common/src/components/Skeleton/Skeleton.tsx
@@ -15,7 +15,7 @@ interface SkeletonProps {
   small?: boolean;
 }
 
-const Skeleton: React.FC<SkeletonProps> = ({
+const Skeleton: React.SFC<SkeletonProps> = ({
   className,
   numberOfLines,
   small

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -28,8 +28,7 @@
     "@kata-kit/button": "^0.7.2",
     "@kata-kit/loading": "^0.7.0",
     "@kata-kit/theme": "^0.7.0",
-    "classnames": "^2.2.6",
-    "lodash-es": "^4.17.11"
+    "classnames": "^2.2.6"
   },
   "peerDependencies": {
     "react": "^16.3.0",
@@ -37,7 +36,6 @@
     "styled-components": "^4.1.2"
   },
   "devDependencies": {
-    "@types/classnames": "^2.2.7",
-    "@types/lodash-es": "^4.17.1"
+    "@types/classnames": "^2.2.7"
   }
 }

--- a/packages/dropdown/src/components/Dropdown.tsx
+++ b/packages/dropdown/src/components/Dropdown.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import classNames from 'classnames';
-import omit from 'lodash-es/omit';
 import styled from 'styled-components';
 
 import { Theme } from '@kata-kit/theme';
@@ -90,14 +89,17 @@ class Dropdown extends React.Component<DropdownProps> {
   }
 
   render() {
+    // Omit these properties from `this.props`
+    const { isOpen: _, ...props } = this.props;
+
     const {
       className,
       children,
       block,
       dropDirection,
       disabled,
-      ...props
-    } = omit(this.props, ['isOpen']);
+      ...rest
+    } = props;
 
     const classes = classNames(className);
 
@@ -111,7 +113,7 @@ class Dropdown extends React.Component<DropdownProps> {
             dropDirection={dropDirection}
             disabled={disabled}
             {...themeAttributes}
-            {...props}
+            {...rest}
           >
             {React.Children.map(children, (Item: React.ReactElement<any>) => {
               return Item &&
@@ -120,7 +122,7 @@ class Dropdown extends React.Component<DropdownProps> {
                   type => type === (Item.type as any).displayName
                 )
                 ? React.cloneElement(Item, {
-                    ...props,
+                    ...rest,
                     dropDirection,
                     isOpen: this.state.isOpen,
                     toggle: this.toggle,

--- a/packages/dropdown/src/components/DropdownToggle.tsx
+++ b/packages/dropdown/src/components/DropdownToggle.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import styled, { css } from 'styled-components';
-import omit from 'lodash-es/omit';
 import classNames from 'classnames';
 
 import { ButtonColors, ButtonSizes } from '@kata-kit/button';
@@ -85,6 +84,13 @@ class DropdownToggle extends React.Component<DropdownToggleProps> {
   }
 
   render() {
+    // Omit these properties from `this.props`
+    const {
+      dropDirection: _dropDirection,
+      toggle: _toggle,
+      ...props
+    } = this.props;
+
     const {
       tag,
       children,
@@ -93,13 +99,13 @@ class DropdownToggle extends React.Component<DropdownToggleProps> {
       block,
       isOpen,
       filled,
-      ...props
-    } = omit(this.props, ['direction', 'toggle']);
+      ...rest
+    } = props;
 
     if (!React.isValidElement(children)) {
       return (
         <DropdownToggleButton
-          {...props}
+          {...rest}
           block
           isOpen={isOpen}
           className={classNames(
@@ -116,7 +122,7 @@ class DropdownToggle extends React.Component<DropdownToggleProps> {
     }
 
     return (
-      <div {...props} className={className} onClick={this.onClick}>
+      <div {...rest} className={className} onClick={this.onClick}>
         {this.renderChildren()}
       </div>
     );

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -27,15 +27,13 @@
   "dependencies": {
     "@kata-kit/button": "^0.7.2",
     "@kata-kit/theme": "^0.7.0",
-    "classnames": "^2.2.6",
-    "lodash-es": "^4.17.11"
+    "classnames": "^2.2.6"
   },
   "peerDependencies": {
     "react": "^16.3.0",
     "styled-components": "^4.1.2"
   },
   "devDependencies": {
-    "@types/classnames": "^2.2.7",
-    "@types/lodash-es": "^4.17.1"
+    "@types/classnames": "^2.2.7"
   }
 }

--- a/packages/pagination/src/Pagination.tsx
+++ b/packages/pagination/src/Pagination.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import styled from 'styled-components';
-import isNumber from 'lodash-es/isNumber';
 import classnames from 'classnames';
 
 import { Theme } from '@kata-kit/theme';
@@ -104,9 +103,9 @@ class Pagination extends React.Component<PaginationProps, PaginationState> {
                   page === current && 'is-active'
                 )}
                 onClick={() =>
-                  isNumber(page) ? this.props.onSelect(page) : null
+                  typeof page === 'number' ? this.props.onSelect(page) : null
                 }
-                disabled={!isNumber(page)}
+                disabled={typeof page !== 'number'}
               >
                 {page}
               </PaginationButton>

--- a/packages/pagination/src/Pagination.tsx
+++ b/packages/pagination/src/Pagination.tsx
@@ -33,8 +33,8 @@ class Pagination extends React.Component<PaginationProps, PaginationState> {
     const maxButtons = 5;
     const pageButtons: React.ReactText[] = [];
 
-    let startPage;
-    let endPage;
+    let startPage: number;
+    let endPage: number;
 
     if (maxButtons && maxButtons < total) {
       startPage = Math.max(

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -28,6 +28,7 @@
     "@kata-kit/theme": "^0.7.0",
     "classnames": "^2.2.6",
     "dom-helpers": "^3.4.0",
+    "lodash-es": "^4.17.11",
     "react-overlays": "^0.8.3"
   },
   "peerDependencies": {
@@ -37,6 +38,8 @@
   },
   "devDependencies": {
     "@types/classnames": "^2.2.7",
+    "@types/dom-helpers": "^3.4.1",
+    "@types/lodash-es": "^4.17.1",
     "@types/react-overlays": "^0.8.5"
   }
 }

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -28,7 +28,6 @@
     "@kata-kit/theme": "^0.7.0",
     "classnames": "^2.2.6",
     "dom-helpers": "^3.4.0",
-    "lodash-es": "^4.17.11",
     "react-overlays": "^0.8.3"
   },
   "peerDependencies": {
@@ -38,7 +37,6 @@
   },
   "devDependencies": {
     "@types/classnames": "^2.2.7",
-    "@types/lodash-es": "^4.17.1",
     "@types/react-overlays": "^0.8.5"
   }
 }

--- a/packages/tooltip/src/components/Tooltip.tsx
+++ b/packages/tooltip/src/components/Tooltip.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import styled from 'styled-components';
-import omit from 'lodash-es/omit';
 
 import { Theme } from '@kata-kit/theme';
 
@@ -29,14 +28,8 @@ export default class Tooltip extends React.Component<TooltipProps> {
       show,
       children,
       targetNodePosition,
-      ...props
-    } = omit(this.props, [
-      'delay',
-      'positionTop',
-      'positionLeft',
-      'arrowOffsetTop',
-      'arrowOffsetLeft'
-    ]);
+      ...rest
+    } = this.props;
 
     const arrowStyles: any = {};
 
@@ -45,7 +38,7 @@ export default class Tooltip extends React.Component<TooltipProps> {
       targetNodePosition.top
     ) {
       arrowStyles.top = `${Math.ceil(
-        targetNodePosition.top - props.style.top
+        targetNodePosition.top - rest.style.top
       )}px`;
     }
 
@@ -54,16 +47,14 @@ export default class Tooltip extends React.Component<TooltipProps> {
       targetNodePosition.left
     ) {
       arrowStyles.left = `${Math.ceil(
-        targetNodePosition.left -
-          props.style.left -
-          targetNodePosition.width / 2
+        targetNodePosition.left - rest.style.left - targetNodePosition.width / 2
       )}px`;
     }
 
     return (
       <Theme>
         {themeAttributes => (
-          <Root role="tooltip" show={show} {...props}>
+          <Root role="tooltip" show={show} {...rest}>
             <Inner>{children}</Inner>
           </Root>
         )}

--- a/packages/tooltip/src/components/TooltipTarget.tsx
+++ b/packages/tooltip/src/components/TooltipTarget.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
-import contains from 'dom-helpers/query/contains';
+import { flowRight as compose } from 'lodash-es';
 import { Overlay } from 'react-overlays';
-import omit from 'lodash-es/omit';
-import filter from 'lodash-es/filter';
-import compose from 'lodash-es/flowRight';
+import contains from 'dom-helpers/query/contains';
 
 const isExists = (needle: string, haystack: string | string[]): boolean => {
   if (Array.isArray(haystack)) {
@@ -17,9 +15,9 @@ const isExists = (needle: string, haystack: string | string[]): boolean => {
 
 const composeFunctions = (...funcs) => {
   // filter valid functions
-  const validFuncs = filter(funcs, f => f !== null || f === 'function').filter(
-    f => f
-  );
+  const validFuncs = funcs
+    .filter(f => f !== null || f === 'function')
+    .filter(f => f);
 
   return compose(validFuncs);
 };
@@ -59,25 +57,11 @@ interface TooltipTargetState {
   show: boolean;
 }
 
-/**
- * Handle default props using interface.
- * @see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/11640#issuecomment-295155472
- */
-interface DefaultProps {
-  defaultShow: boolean;
-  placement: string;
-  trigger: string | string[];
-  delay: number;
-  onClick(): void;
-}
-
-type PropsWithDefault = TooltipTargetProps & DefaultProps;
-
 export default class TooltipTarget extends React.Component<
   TooltipTargetProps,
   TooltipTargetState
 > {
-  static defaultProps: Partial<TooltipTargetProps> = {
+  static defaultProps = {
     defaultShow: false,
     placement: 'right',
     trigger: ['click', 'hover', 'focus'],
@@ -229,6 +213,7 @@ export default class TooltipTarget extends React.Component<
   }
 
   render() {
+    const { defaultShow, ...props } = this.props;
     const {
       children,
       component,
@@ -238,9 +223,9 @@ export default class TooltipTarget extends React.Component<
       onMouseOut,
       onFocus,
       onBlur,
-      ...props
-    } = omit(this.props as PropsWithDefault, ['defaultShow']);
-    this.overlay = this.createOverlay(component, props);
+      ...rest
+    } = props;
+    this.overlay = this.createOverlay(component, rest);
 
     // Check if children only has ONE child. It will throw error if it has more than one child.
     // Ref: https://reactjs.org/docs/react-api.html#reactchildrenonly
@@ -250,14 +235,14 @@ export default class TooltipTarget extends React.Component<
 
     childTrigger.onClick = composeFunctions(childProps.onClick, onClick);
 
-    if (isExists('click', trigger)) {
+    if (trigger && isExists('click', trigger)) {
       childTrigger.onClick = composeFunctions(
         childTrigger.onClick,
         this.handleToggle
       );
     }
 
-    if (isExists('hover', trigger)) {
+    if (trigger && isExists('hover', trigger)) {
       childTrigger.onMouseOver = composeFunctions(
         childProps.onMouseOver,
         onMouseOver,
@@ -271,7 +256,7 @@ export default class TooltipTarget extends React.Component<
       );
     }
 
-    if (isExists('focus', trigger)) {
+    if (trigger && isExists('focus', trigger)) {
       childTrigger.onFocus = composeFunctions(
         childProps.onFocus,
         onFocus,

--- a/packages/tooltip/src/components/TooltipTarget.tsx
+++ b/packages/tooltip/src/components/TooltipTarget.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
-import { flowRight as compose } from 'lodash-es';
 import { Overlay } from 'react-overlays';
+import compose from 'lodash-es/flowRight';
 import contains from 'dom-helpers/query/contains';
 
 const isExists = (needle: string, haystack: string | string[]): boolean => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2040,6 +2040,11 @@
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-0.0.31.tgz#bac8d8aab6a823e91deb7f79083b2a35fa638f33"
   integrity sha512-LS1MCPaQKqspg7FvexuhmDbWUhE2yIJ+4AgVIyObfc06/UKZ8REgxGNjZc82wPLWmbeOm7S+gSsLgo75TanG4A==
 
+"@types/dom-helpers@^3.4.1":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@types/dom-helpers/-/dom-helpers-3.4.1.tgz#9a9b1be9cbbf289d2192964d65064f1279a3b5ed"
+  integrity sha512-j6d+NJ8TaPKoIdyjJx7nuhhCaNmxZF86wBSc4wAT5AKikwftpPjVKi9HxEKLrmRztFEYRpje6T8W3R7Q9nyHcg==
+
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
@@ -2094,6 +2099,18 @@
   integrity sha512-8DOy0JCGwwAf76xmU0sRzSZCWKSPPA9djRcTYTsyqBPnMdGOjZ5tjmNswC4J9mgKZudte2tuTo1l14R1/t5l/g==
   dependencies:
     "@types/node" "*"
+
+"@types/lodash-es@^4.17.1":
+  version "4.17.3"
+  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.3.tgz#87eb0b3673b076b8ee655f1890260a136af09a2d"
+  integrity sha512-iHI0i7ZAL1qepz1Y7f3EKg/zUMDwDfTzitx+AlHhJJvXwenP682ZyGbgPSc5Ej3eEAKVbNWKFuwOadCj5vBbYQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.123"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.123.tgz#39be5d211478c8dd3bdae98ee75bb7efe4abfe4d"
+  integrity sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q==
 
 "@types/minimatch@*":
   version "3.0.3"
@@ -8234,6 +8251,11 @@ lock-verify@^2.0.2:
   dependencies:
     npm-package-arg "^5.1.2 || 6"
     semver "^5.4.1"
+
+lodash-es@^4.17.11:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.11.tgz#145ab4a7ac5c5e52a3531fb4f310255a152b4be0"
+  integrity sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q==
 
 lodash._getnative@^3.0.0:
   version "3.9.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2095,18 +2095,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/lodash-es@^4.17.1":
-  version "4.17.1"
-  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.1.tgz#56745e5411558362aeca31def918f88f725dd29d"
-  integrity sha512-3EDZjphPfdjnsWvY11ufYImFMPyQJwIH1eFYRgWQsjOctce06fmNgVf5sfvXBRiaS1o0X50bAln1lfWs8ZO3BA==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*":
-  version "4.14.117"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.117.tgz#695a7f514182771a1e0f4345d189052ee33c8778"
-  integrity sha512-xyf2m6tRbz8qQKcxYZa7PA4SllYcay+eh25DN3jmNYY6gSTL7Htc/bttVdkqj2wfJGbeWlQiX8pIyJpKU+tubw==
-
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -8246,11 +8234,6 @@ lock-verify@^2.0.2:
   dependencies:
     npm-package-arg "^5.1.2 || 6"
     semver "^5.4.1"
-
-lodash-es@^4.17.11:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.11.tgz#145ab4a7ac5c5e52a3531fb4f310255a152b4be0"
-  integrity sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q==
 
 lodash._getnative@^3.0.0:
   version "3.9.1"


### PR DESCRIPTION
Some `lodash` uses can already be replaced by its vanilla counterparts,
so let's use that.