### PR TITLE
feat(common): make EmptyMessage images optional

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -25,7 +25,6 @@
     "watch:tsc": "tsc-watch -b --preserveWatchOutput"
   },
   "dependencies": {
-    "@kata-kit/assets": "^0.7.0",
     "@kata-kit/theme": "^0.7.1",
     "classnames": "^2.2.6",
     "focus-trap": "^3.0.0"

--- a/packages/common/src/components/EmptyMessage/EmptyMessage.tsx
+++ b/packages/common/src/components/EmptyMessage/EmptyMessage.tsx
@@ -14,16 +14,17 @@ interface Props {
 
 export default class EmptyMessage extends React.Component<Props> {
   static defaultProps = {
-    image: require('@kata-kit/assets/images/form-empty.svg'),
+    image: undefined,
     title: 'Empty'
   };
 
   render() {
+    const { className, style, image, title, children } = this.props;
     return (
-      <Wrapper className={this.props.className} style={this.props.style}>
-        <img src={this.props.image} alt="Empty Message" />
-        <Title data-testid="EmptyMessage-title">{this.props.title}</Title>
-        <Description>{this.props.children}</Description>
+      <Wrapper className={className} style={style}>
+        {image && <img src={image} alt="Empty Message" />}
+        <Title data-testid="EmptyMessage-title">{title}</Title>
+        <Description>{children}</Description>
       </Wrapper>
     );
   }


### PR DESCRIPTION
When no image is passed, `EmptyMessage` should show no image at all or no fallback assets from `@wicara/assets` should be pulled.