### PR TITLE
fix(modal): allow temporarily disabling focus trap

### DIFF
--- a/packages/drawer/src/components/Drawer.tsx
+++ b/packages/drawer/src/components/Drawer.tsx
@@ -139,6 +139,7 @@ class Drawer extends React.Component<DrawerProps, DrawerState> {
               role="dialog"
               aria-modal="true"
               aria-labelledby={this.props.labelledById}
+              onKeyDown={this.handleKeyDown}
             >
               <DrawerContext.Provider value={this.getContextAPI()}>
                 {this.state.isOpen && this.props.children}

--- a/packages/modal/src/__tests__/Modal.test.tsx
+++ b/packages/modal/src/__tests__/Modal.test.tsx
@@ -23,6 +23,21 @@ describe('Modal', () => {
     expect(wrapper).toHaveClass('is-open');
   });
 
+  test('renders correctly (no focus trap)', () => {
+    const { getByTestId } = render(
+      <Modal show disableFocusTrap onClose={handleClose}>
+        <ModalHeader title="Modal" />
+        <ModalBody>
+          <p>Modal Body</p>
+        </ModalBody>
+        <ModalFooter>Footer</ModalFooter>
+      </Modal>
+    );
+
+    const wrapper = getByTestId('Modal-wrapper');
+    expect(wrapper).toHaveClass('is-open');
+  });
+
   test('has visibility: hidden when show === false', () => {
     const { getByTestId } = render(
       <Modal show={false} onClose={handleClose}>

--- a/packages/modal/src/components/Modal.tsx
+++ b/packages/modal/src/components/Modal.tsx
@@ -19,6 +19,8 @@ export interface ModalProps {
   className?: string;
   /** Used to reference the ID of the title element in the modal */
   labelledById?: string;
+  /** Disables focus trap mode. */
+  disableFocusTrap?: boolean;
   /** Callback method run when the Close button is clicked. */
   onClose(): void;
 }
@@ -34,7 +36,8 @@ export interface ModalState {
 
 class Modal extends React.Component<ModalProps, ModalState> {
   static defaultProps = {
-    noBackdrop: false
+    noBackdrop: false,
+    disableFocusTrap: false
   };
 
   el: HTMLDivElement;
@@ -105,36 +108,78 @@ class Modal extends React.Component<ModalProps, ModalState> {
   }
 
   render() {
-    const wrapper = (
-      <FocusTrap active={this.state.show} onKeyDown={this.handleKeyDown}>
-        {!this.props.noBackdrop && (
-          <ModalOverlay
-            className={classnames(this.state.show ? 'is-open' : 'is-closed')}
-            onClick={this.onCloseDrawer}
-          />
-        )}
-        <Theme>
-          {themeAttributes => (
-            <ModalWrapper
-              data-testid="Modal-wrapper"
-              className={classnames(
-                this.state.show ? 'is-open' : 'is-closed',
-                this.props.className
-              )}
-              onClick={!this.props.noBackdrop ? this.onCloseDrawer : undefined}
-              role="dialog"
-              aria-modal="true"
-              aria-labelledby={this.props.labelledById}
-              {...themeAttributes}
-            >
-              <ModalContext.Provider value={this.getContextAPI()}>
-                <ModalDialog>{this.props.children}</ModalDialog>
-              </ModalContext.Provider>
-            </ModalWrapper>
+    const { disableFocusTrap } = this.props;
+    let wrapper: JSX.Element;
+
+    if (disableFocusTrap) {
+      wrapper = (
+        <>
+          {!this.props.noBackdrop && (
+            <ModalOverlay
+              className={classnames(this.state.show ? 'is-open' : 'is-closed')}
+              onClick={this.onCloseDrawer}
+            />
           )}
-        </Theme>
-      </FocusTrap>
-    );
+          <Theme>
+            {themeAttributes => (
+              <ModalWrapper
+                data-testid="Modal-wrapper"
+                className={classnames(
+                  this.state.show ? 'is-open' : 'is-closed',
+                  this.props.className
+                )}
+                onClick={
+                  !this.props.noBackdrop ? this.onCloseDrawer : undefined
+                }
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby={this.props.labelledById}
+                onKeyDown={this.handleKeyDown}
+                {...themeAttributes}
+              >
+                <ModalContext.Provider value={this.getContextAPI()}>
+                  <ModalDialog>{this.props.children}</ModalDialog>
+                </ModalContext.Provider>
+              </ModalWrapper>
+            )}
+          </Theme>
+        </>
+      );
+    } else {
+      wrapper = (
+        <FocusTrap active={this.state.show} onKeyDown={this.handleKeyDown}>
+          {!this.props.noBackdrop && (
+            <ModalOverlay
+              className={classnames(this.state.show ? 'is-open' : 'is-closed')}
+              onClick={this.onCloseDrawer}
+            />
+          )}
+          <Theme>
+            {themeAttributes => (
+              <ModalWrapper
+                data-testid="Modal-wrapper"
+                className={classnames(
+                  this.state.show ? 'is-open' : 'is-closed',
+                  this.props.className
+                )}
+                onClick={
+                  !this.props.noBackdrop ? this.onCloseDrawer : undefined
+                }
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby={this.props.labelledById}
+                {...themeAttributes}
+              >
+                <ModalContext.Provider value={this.getContextAPI()}>
+                  <ModalDialog>{this.props.children}</ModalDialog>
+                </ModalContext.Provider>
+              </ModalWrapper>
+            )}
+          </Theme>
+        </FocusTrap>
+      );
+    }
+
     return createPortal(wrapper, this.el) as React.ReactPortal;
   }
 }


### PR DESCRIPTION
The `FocusTrap` helper component has been giving issues on some use
cases, e.g. file inputs. We added an additional prop to allow optionally
disabling said focus trap.