### PR TITLE
feat(card): support `elevation` prop

### DIFF
--- a/packages/wicara-core/src/Theme.tsx
+++ b/packages/wicara-core/src/Theme.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { ThemeProvider } from 'styled-components';
-import { colors, space, fonts, typeScale, breakpoints, shadows, radii } from './utils';
+import { colors, space, fonts, typeScale, elevation, breakpoints, shadows, radii } from './utils';
 
 export const themeProps = {
+  // Default styled-system theme props based on the theme specification:
+  // https://styled-system.com/theme-specification
   colors,
   space,
   fonts,
-  typeScale,
   shadows,
   radii,
   breakpoints: [
@@ -14,7 +15,11 @@ export const themeProps = {
     `${breakpoints.md}px`,
     `${breakpoints.lg}px`,
     `${breakpoints.xl}px`
-  ]
+  ],
+
+  // Custom theme props based on custom component variants.
+  typeScale,
+  elevation
 };
 
 export const Theme: React.FC = ({ children }) => {
@@ -23,4 +28,5 @@ export const Theme: React.FC = ({ children }) => {
 
 export type Color = keyof typeof themeProps['colors'];
 export type Space = keyof typeof themeProps['space'];
+export type Elevation = keyof typeof themeProps['elevation'];
 export type TypeScale = keyof typeof themeProps['typeScale'];

--- a/packages/wicara-core/src/components/dialog/components/Dialog.tsx
+++ b/packages/wicara-core/src/components/dialog/components/Dialog.tsx
@@ -168,9 +168,7 @@ class Dialog extends React.Component<DialogProps, DialogState> {
           className={clsx(isOpen && 'entered')}
           display="flex"
           flexDirection="column"
-          backgroundColor="white"
-          boxShadow="layer300"
-          borderRadius="lg"
+          elevation="layer300"
           width="100%"
           maxWidth="500px"
           maxHeight="calc(100% - 24vmin)"

--- a/packages/wicara-core/src/components/side-sheet/components/SideSheet.tsx
+++ b/packages/wicara-core/src/components/side-sheet/components/SideSheet.tsx
@@ -169,8 +169,8 @@ class SideSheet extends React.Component<SideSheetProps, SideSheetState> {
           <Card
             display="flex"
             flexDirection="column"
-            backgroundColor="white"
-            boxShadow="layer300"
+            elevation="layer300"
+            borderRadius={0}
             width="500px"
             height="100vh"
           >

--- a/packages/wicara-core/src/foundations/box/components/Box.tsx
+++ b/packages/wicara-core/src/foundations/box/components/Box.tsx
@@ -17,7 +17,9 @@ import {
   typography,
   TypographyProps,
   border,
-  BorderProps
+  BorderProps,
+  shadow,
+  ShadowProps
 } from 'styled-system';
 
 import { primitives } from '../../../utils/primitives';
@@ -31,7 +33,8 @@ export interface BoxProps
     BackgroundProps,
     ColorProps,
     TypographyProps,
-    BorderProps {
+    BorderProps,
+    ShadowProps {
   /** Additional CSS classes to add to the component. */
   className?: string;
   /** Additional CSS properties to add to the component. */
@@ -52,6 +55,7 @@ const Box = primitives.View<BoxProps>`
   ${color}
   ${typography}
   ${border}
+  ${shadow}
 `;
 
 Box.displayName = 'Box';

--- a/packages/wicara-core/src/foundations/card/components/Card.tsx
+++ b/packages/wicara-core/src/foundations/card/components/Card.tsx
@@ -1,16 +1,36 @@
 import styled from 'styled-components';
-import { shadow, ShadowProps } from 'styled-system';
-import { Box } from '../../box';
+import { variant } from 'styled-system';
+import { Box, BoxProps } from '../../box';
+import { Elevation } from '../../../Theme';
 
-export type CardProps = ShadowProps;
+export interface CardProps extends BoxProps {
+  elevation?: Elevation;
+}
 
 /**
- * Card is similar to `Box`, but with additional `shadow` and `border` styled-system hooks.
+ * Renders a card based on the elevation level.
  */
 const Card = styled(Box)<CardProps>`
-  ${shadow}
-  overflow: hidden;
+  ${variant({
+    prop: 'elevation',
+    scale: 'elevation',
+    variants: {
+      // NOTE: The empty objects here is important.
+      // https://styled-system.com/variants#migrating-from-legacy-api
+      layer100: {},
+      layer200: {},
+      layer300: {},
+      layer400: {}
+    }
+  })}
 `;
+
+Card.defaultProps = {
+  backgroundColor: 'white',
+  borderRadius: 'md',
+  overflow: 'hidden',
+  elevation: 'layer100'
+};
 
 Card.displayName = 'Card';
 

--- a/packages/wicara-core/src/foundations/card/index.stories.tsx
+++ b/packages/wicara-core/src/foundations/card/index.stories.tsx
@@ -36,8 +36,20 @@ story.add(
   () => (
     <WicaraProvider>
       <Box padding="sm">
-        <Card padding="md" background="white" boxShadow="layer100" borderRadius="md">
-          I&apos;m inside a card!
+        <Card mb="md" p="md">
+          I&apos;m inside a card! (layer100)
+        </Card>
+
+        <Card mb="md" p="md" elevation="layer200">
+          I&apos;m inside a card! (layer200)
+        </Card>
+
+        <Card mb="md" p="md" elevation="layer300">
+          I&apos;m inside a card! (layer300)
+        </Card>
+
+        <Card mb="md" p="md" elevation="layer400">
+          I&apos;m inside a card! (layer400)
         </Card>
       </Box>
     </WicaraProvider>
@@ -55,14 +67,7 @@ story.add(
         <StoryContainer>
           <Box display="flex" flexWrap="wrap" position="relative">
             <Anchor href="https://www.google.com/" target="_blank">
-              <Card
-                display="flex"
-                flex={1}
-                flexDirection="column"
-                bg="white"
-                borderRadius="md"
-                boxShadow="layer100"
-              >
+              <Card display="flex" flex={1} flexDirection="column">
                 <img
                   alt="Example"
                   src="https://picsum.photos/id/873/1072/708"

--- a/packages/wicara-core/src/utils/variables.ts
+++ b/packages/wicara-core/src/utils/variables.ts
@@ -136,12 +136,33 @@ export const radii = {
   lg: 8
 };
 
-/** Default box/text shadow separated by layers */
-export const shadows = {
+/** Legacy box-shadow values. */
+export const shadowsLegacy = {
   layer100: '0 1px 1px 0 rgba(0, 0, 0, 0.25)',
   layer200: '0 2px 4px 1px rgba(0, 0, 0, 0.15)',
   layer300: '0 4px 6px 2px rgba(0, 0, 0, 0.15)',
   layer400: '0 6px 10px 2px rgba(0, 0, 0, 0.15)'
+};
+
+/** Default box/text shadow separated by layers */
+export const shadows = {
+  ...shadowsLegacy
+};
+
+/** Custom elevation variant for the Card component. */
+export const elevation = {
+  layer100: {
+    boxShadow: 'layer100'
+  },
+  layer200: {
+    boxShadow: 'layer200'
+  },
+  layer300: {
+    boxShadow: 'layer300'
+  },
+  layer400: {
+    boxShadow: 'layer400'
+  }
 };
 
 /** Typography scale values (in pixels) mapped by style tokens. */


### PR DESCRIPTION
This PR refactors some of the `Box` + `Card` functionalities to support
the `elevation` prop using `styled-system`'s `variant` API.

Fixes #172